### PR TITLE
Fixed duplicator error for doors, docks and lift designer

### DIFF
--- a/lua/entities/sbep_base_docking_clamp/shared.lua
+++ b/lua/entities/sbep_base_docking_clamp/shared.lua
@@ -4,7 +4,7 @@ ENT.PrintName		= "Base Docking Clamp"
 ENT.Author			= "Paradukes, Hysteria"
 ENT.Category		= "SBEP"
 
-ENT.Spawnable		= true
+ENT.Spawnable		= false
 ENT.AdminSpawnable	= false
 ENT.Owner			= nil
 ENT.CPL				= nil

--- a/lua/entities/sbep_base_door/shared.lua
+++ b/lua/entities/sbep_base_door/shared.lua
@@ -5,7 +5,7 @@ ENT.Author			      = "Hysteria"
 ENT.Category			  = "SBEP"
 
 ENT.AutomaticFrameAdvance = true
-ENT.Spawnable			  = true
+ENT.Spawnable			  = false
 ENT.AdminSpawnable		  = false
 
 ENT.Purpose 		      = "To open and close."

--- a/lua/weapons/gmod_tool/stools/sbep_docking_clamp.lua
+++ b/lua/weapons/gmod_tool/stools/sbep_docking_clamp.lua
@@ -24,6 +24,24 @@ CategoryTable[1] = {
 TOOL.ClientConVar[ "model" 		] = "models/smallbridge/panels/sbpaneldockin.mdl"
 TOOL.ClientConVar[ "allowuse"   ] = 1
 
+if ( SERVER ) then
+
+	function MakeDockingClamp( Player, Data )
+
+		local DockEnt = ents.Create( "sbep_base_docking_clamp" )
+		duplicator.DoGeneric( DockEnt, Data )
+		DockEnt:Spawn()
+
+		duplicator.DoGenericPhysics( DockEnt, Player, Data )
+
+		return DockEnt
+
+	end
+
+	duplicator.RegisterEntityClass( "sbep_base_docking_clamp", MakeDockingClamp, "Data" )
+	
+end
+
 function TOOL:LeftClick( tr )
 
 	if CLIENT then return end

--- a/lua/weapons/gmod_tool/stools/sbep_door.lua
+++ b/lua/weapons/gmod_tool/stools/sbep_door.lua
@@ -35,6 +35,24 @@ TOOL.ClientConVar[ "model"  	] = "models/SmallBridge/Panels/sbpaneldoor.mdl"
 TOOL.ClientConVar[ "wire"  		] = 1
 TOOL.ClientConVar[ "enableuse"	] = 1
 
+if ( SERVER ) then
+
+	function MakeDoorController( Player, Data )
+
+		local DoorController = ents.Create( "sbep_base_door_controller" )
+		duplicator.DoGeneric( DoorController, Data )
+		DoorController:Spawn()
+
+		duplicator.DoGenericPhysics( DoorController, Player, Data )
+
+		return DoorController
+
+	end
+
+	duplicator.RegisterEntityClass( "sbep_base_door_controller", MakeDoorController, "Data" )
+	
+end
+
 function TOOL:LeftClick( tr )
 
 	if CLIENT then return end

--- a/lua/weapons/gmod_tool/stools/sbep_lift_designer.lua
+++ b/lua/weapons/gmod_tool/stools/sbep_lift_designer.lua
@@ -658,6 +658,20 @@ util.AddNetworkString("SBEP_SetPHOffsetLiftDesignMenu_cl")
 		ply:ConCommand( "SBEP_LiftGetCamHeight_ser" )
 	end
 	concommand.Add( "SBEP_LiftDeletePart_ser" , SBEP_LiftDeletePart )
+
+	function MakeLift( Player, Data )
+
+		local ent = ents.Create( Data.Class )
+		duplicator.DoGeneric( ent, Data )
+		ent:Spawn()
+
+		duplicator.DoGenericPhysics( ent, Player, Data )
+
+		return ent
+
+	end
+	duplicator.RegisterEntityClass( "sbep_elev_housing", MakeLift, "Data" )
+	duplicator.RegisterEntityClass( "sbep_elev_system", MakeLift, "Data" )
 	
 	/*reset convars to defaults on load
 	for k,v in pairs( ConVars ) do


### PR DESCRIPTION
Advduplicator2 was complaining about black listed entities and not spawning these.
This happens if entities are not set to Spawnable or entity class was not registered to duplicator.
This commit also makes it work with garry's duplicator.